### PR TITLE
Speed up nested searchable lookup

### DIFF
--- a/src/main/java/com/gisgro/utils/ReflectionUtils.java
+++ b/src/main/java/com/gisgro/utils/ReflectionUtils.java
@@ -22,8 +22,7 @@ public class ReflectionUtils {
     }
 
     private static void getAllSearchableFields(final StringBuilder root, Class<?> beanClass, Map<String, Pair<Searchable, Class<?>>> res) {
-
-        Stream.of(BeanUtils.getPropertyDescriptors(beanClass)).flatMap(pd -> Stream.of(pd.getReadMethod().getDeclaringClass().getDeclaredFields()))
+        Stream.of(beanClass.getDeclaredFields())
             .forEach(f -> {
                 if (f.isAnnotationPresent(Searchable.class)) {
                     res.putIfAbsent(root.isEmpty() ? f.getName() : root + "." + f.getName(), Pair.of(f.getAnnotation(Searchable.class), f.getType()));


### PR DESCRIPTION
`getAllSearchableFields()` used to get declared fields via property descriptors' read method's declaring classes, which in practice means that for each property descriptor, it did a full nested scan of each of the declared fields of the PD's read method's declaring class. With just a few nested levels, a single root got searched tens of thousands of times over and over, making the method take minutes to run. Now we're simply getting the original class's declared fields.

Not sure if there indeed was originally a rationale for such a solution, but if it turns out to be necessary for some reason, another simple way to speed this up would be to store visited roots in a set and visiting them only once.