### PR TITLE
Reflection fixes

### DIFF
--- a/src/main/java/com/gisgro/utils/ReflectionUtils.java
+++ b/src/main/java/com/gisgro/utils/ReflectionUtils.java
@@ -2,9 +2,14 @@ package com.gisgro.utils;
 
 import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
+import com.gisgro.exceptions.JPASearchException;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.BeanUtils;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.WildcardType;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,23 +21,30 @@ public class ReflectionUtils {
     public static Map<String, Pair<Searchable, Class<?>>> getAllSearchableFields(Class<?> beanClass) {
         return cache.computeIfAbsent(beanClass, key -> {
             Map<String, Pair<Searchable, Class<?>>> res = new HashMap<>();
-            getAllSearchableFields(new StringBuilder(), beanClass, res);
+            getAllSearchableFields(new StringBuilder(), beanClass, res, true);
             return res;
         });
     }
 
-    private static void getAllSearchableFields(final StringBuilder root, Class<?> beanClass, Map<String, Pair<Searchable, Class<?>>> res) {
-        Stream.of(beanClass.getDeclaredFields())
+    private static void getAllSearchableFields(
+            final StringBuilder root,
+            Class<?> beanClass,
+            Map<String, Pair<Searchable, Class<?>>> res,
+            boolean evaluateNested
+    ) {
+        Stream.of(FieldUtils.getAllFields(beanClass))
             .forEach(f -> {
                 if (f.isAnnotationPresent(Searchable.class)) {
                     res.putIfAbsent(root.isEmpty() ? f.getName() : root + "." + f.getName(), Pair.of(f.getAnnotation(Searchable.class), f.getType()));
                 }
-                if (f.isAnnotationPresent(NestedSearchable.class)) {
+                if (evaluateNested && f.isAnnotationPresent(NestedSearchable.class)) {
                     if (!root.isEmpty()) {
                         root.append(".");
                     }
                     root.append(f.getName());
-                    getAllSearchableFields(root, f.getType(), res);
+
+                    var type = getType(f);
+                    getAllSearchableFields(root, type, res, !type.equals(beanClass));
 
                     if (root.indexOf(".") != -1) {
                         root.delete(root.lastIndexOf("."), root.length());
@@ -42,5 +54,29 @@ public class ReflectionUtils {
                     }
                 }
             });
+    }
+
+    public static Class<?> getType(Field f) {
+        Class<?> type = f.getType();
+
+        if (Collection.class.isAssignableFrom(f.getType())) {
+            var arr = ((ParameterizedType) f.getGenericType()).getActualTypeArguments();
+            if (arr.length > 0) {
+                if (arr[0] instanceof Class<?> clazz) {
+                    return clazz;
+
+                } else if (arr[0] instanceof WildcardType wt) {
+                    if (wt.getLowerBounds().length > 0) {
+                        return (Class<?>) wt.getLowerBounds()[0];
+                    } else if (wt.getUpperBounds().length > 0) {
+                        return (Class<?>) wt.getUpperBounds()[0];
+                    }
+                }
+            }
+
+            throw new JPASearchException("Invalid searchable type " + f.getType());
+        }
+
+        return type;
     }
 }

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -151,8 +151,8 @@ public class JpaSearchTests {
     }
 
     private void setup3() {
-        var foo = testEntity3Repository.save(new TestEntity3(0L, "foo", null));
-        testEntity3Repository.save(new TestEntity3(0L, "bar", foo));
+        var foo = testEntity3Repository.save(new TestEntity3(0L, "parentFoo", "foo", null));
+        testEntity3Repository.save(new TestEntity3(0L, "parentBar", "bar", foo));
     }
 
     @SneakyThrows
@@ -163,6 +163,7 @@ public class JpaSearchTests {
         var filterString = """
             {"filter":
                 ["and",
+                 ["eq", ["field", "parentField"], "parentBar"],
                  ["eq", ["field", "payload"], "bar"],
                  ["eq", ["field", "previous.payload"], "foo"]
                 ]}

--- a/src/test/java/com/gisgro/ParentEntity.java
+++ b/src/test/java/com/gisgro/ParentEntity.java
@@ -1,0 +1,23 @@
+package com.gisgro;
+
+import com.gisgro.annotations.NestedSearchable;
+import com.gisgro.annotations.Searchable;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+public class ParentEntity {
+    public ParentEntity() {}
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Searchable
+    private String parentField;
+}

--- a/src/test/java/com/gisgro/TestEntity3.java
+++ b/src/test/java/com/gisgro/TestEntity3.java
@@ -4,6 +4,7 @@ import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
@@ -11,13 +12,18 @@ import javax.persistence.*;
 @Entity
 @Getter
 @Setter
-@AllArgsConstructor
-public class TestEntity3 {
-    public TestEntity3() {}
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@NoArgsConstructor
+public class TestEntity3 extends ParentEntity {
+    public TestEntity3(
+            Long id,
+            String parentValue,
+            String payload,
+            TestEntity3 previous
+    ) {
+        super(id, parentValue);
+        this.payload = payload;
+        this.previous = previous;
+    }
 
     @Searchable
     private String payload;

--- a/src/test/java/com/gisgro/TestEntity3.java
+++ b/src/test/java/com/gisgro/TestEntity3.java
@@ -1,0 +1,28 @@
+package com.gisgro;
+
+import com.gisgro.annotations.NestedSearchable;
+import com.gisgro.annotations.Searchable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+public class TestEntity3 {
+    public TestEntity3() {}
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Searchable
+    private String payload;
+
+    @ManyToOne
+    @NestedSearchable
+    public TestEntity3 previous;
+}

--- a/src/test/java/com/gisgro/TestEntity3Repository.java
+++ b/src/test/java/com/gisgro/TestEntity3Repository.java
@@ -1,0 +1,8 @@
+package com.gisgro;
+
+import com.gisgro.repository.JPASearchRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestEntity3Repository extends JpaRepository<TestEntity3, Long>, JPASearchRepository<TestEntity3> {}


### PR DESCRIPTION
- Use FieldUtils.getAllFields() for getting fields (to include superclass fields)
- Fix reflection of recursive structures (adapted from https://github.com/biagioT/jpa-search-helper/commit/a71647b8b109d3b1f4526d792ca032c88e273de2)