### PR TITLE
Has operator for nested collection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.gisgro"
-version = "2.0.13"
+version = "2.0.15-alpha1"
 
 java.apply {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/com/gisgro/JPASearchCore.java
+++ b/src/main/java/com/gisgro/JPASearchCore.java
@@ -7,6 +7,7 @@ import com.gisgro.exceptions.JPASearchException;
 import com.gisgro.model.Operator;
 import com.gisgro.model.SearchType;
 import com.gisgro.utils.ReflectionUtils;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +40,22 @@ public class JPASearchCore {
             boolean throwsIfNotExistsOrNotSearchable,
             Set<Class<?>> searchableSubclasses
     ) {
+        return specification(
+                filterPayload,
+                entityClass,
+                throwsIfNotExistsOrNotSearchable,
+                searchableSubclasses,
+                Collections.emptyMap()
+        );
+    }
+
+    public static <R, T> Specification<R> specification(
+            JsonNode filterPayload,
+            Class<T> entityClass,
+            boolean throwsIfNotExistsOrNotSearchable,
+            Set<Class<?>> searchableSubclasses,
+            Map<String, Class<?>> searchableCollectionTargetClasses
+    ) {
         HashSet<Class<?>> entityClasses = new HashSet<>(searchableSubclasses);
         entityClasses.add(entityClass);
 
@@ -54,7 +71,8 @@ public class JPASearchCore {
                     entityClass,
                     entityClasses,
                     throwsIfNotExistsOrNotSearchable,
-                    searchableFields
+                    searchableFields,
+                    searchableCollectionTargetClasses
             );
             if (expr instanceof Predicate) {
                 return (Predicate) expr;
@@ -63,17 +81,71 @@ public class JPASearchCore {
             }
         };
     }
+    private static <T, X> Object processSubValue(
+        Operator op,
+        JsonNode node,
+        CriteriaBuilder cb,
+        Root<T> root,
+        Subquery<X> subquery,
+        Class<?> entityClass,
+        Set<Class<?>> entityClasses,
+        boolean throwsIfNotExistsOrNotSearchable,
+        Map<String, List<Field>> searchableFields,
+        Map<String, Class<?>> searchableCollectionTargetClasses
+    ) {
+        if (node.isTextual()) {
+            var text = node.asText();
+            if (Objects.equals(op.getName(), "field")) {
+                return processField(
+                    cb,
+                    root,
+                    throwsIfNotExistsOrNotSearchable,
+                    searchableFields,
+                    text
+                );
+            } else if (!op.isEvaluateStrings()) {
+                return text;
+            } else {
+                return cb.literal(text);
+            }
+        } else if (node.isInt()) {
+            return cb.literal(node.asInt());
+        } else if (node.isLong()) {
+            return cb.literal(node.asLong());
+        } else if (node.isDouble()) {
+            return cb.literal(node.asDouble());
+        } else if (node.isBoolean()) {
+            return cb.literal(node.asBoolean());
+        } else if (node.isArray()) {
+            return processSubExpression(
+                node,
+                cb,
+                root,
+                subquery,
+                entityClass,
+                entityClasses,
+                throwsIfNotExistsOrNotSearchable,
+                searchableFields,
+                searchableCollectionTargetClasses
+            );
+        } else if (node.isNull()) {
+            return cb.nullLiteral(entityClass);
+        } else {
+            throw new JPASearchException("unexpected: " + node);
+        }
+    }
 
     private static <T> Object processValue(
             Operator op,
             JsonNode node,
             CriteriaBuilder cb,
-            Root<?> root,
+            Root<T> root,
             CriteriaQuery<?> query,
             Class<?> entityClass,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
-            Map<String, List<Field>> searchableFields
+            Map<String, List<Field>> searchableFields,
+            Map<String, Class<?>> searchableCollectionTargetClasses
     ) {
         if (node.isTextual()) {
             var text = node.asText();
@@ -107,7 +179,8 @@ public class JPASearchCore {
                     entityClass,
                     entityClasses,
                     throwsIfNotExistsOrNotSearchable,
-                    searchableFields
+                    searchableFields,
+                    searchableCollectionTargetClasses
             );
         } else if (node.isNull()) {
             return cb.nullLiteral(entityClass);
@@ -146,6 +219,85 @@ public class JPASearchCore {
 
         return path;
     }
+    private static Expression<?> processSubExpression(
+        JsonNode node,
+        CriteriaBuilder cb,
+        Root<?> root,
+        Subquery<?> query,
+        Class<?> entityClass,
+        Set<Class<?>> entityClasses,
+        boolean throwsIfNotExistsOrNotSearchable,
+        final Map<String, List<Field>> searchableFields,
+        Map<String, Class<?>> searchableCollectionTargetClasses
+    ) {
+        if (!node.isArray() || node.isEmpty() || !node.get(0).isTextual()) {
+            throw new JPASearchException("Invalid expression");
+        }
+
+        var op = Operator.load(node.get(0).textValue());
+        var arguments = new ArrayList<>();
+        if (op.getName().equals("has")) {
+            var attrName = node.get(1).asText();
+            var subClass = searchableCollectionTargetClasses.get(attrName);
+            Subquery subquery = query.subquery(subClass);
+            Root subRoot = subquery.from(subClass);
+
+            Map<String, Class<?>> subMap = searchableCollectionTargetClasses.entrySet().stream()
+                .filter(c -> c.getKey().startsWith(attrName) && c.getKey().length() > attrName.length() + 1)
+                .map(c -> {
+                    var newKey = c.getKey().substring(attrName.length() + 1);
+                    return Map.entry(newKey, c.getValue());
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            var subFields = ReflectionUtils.getAllSearchableFields(Set.of(subClass));
+            var subCriteriaBuilder = cb;
+
+            var subValue = processSubValue(
+                    op,
+                    node.get(2),
+                    subCriteriaBuilder,
+                    subRoot,
+                    subquery,
+                    subClass,
+                    entityClasses, // pass through to support nested situations
+                    throwsIfNotExistsOrNotSearchable,
+                    subFields,
+                    subMap
+            );
+
+            subquery.select(subRoot).where((Predicate) subValue);
+
+            var rootSubquery = query.subquery(root.getJavaType());
+            var rootSubRoot = rootSubquery.from(root.getJavaType());
+            var rootSubPredicate = rootSubRoot.join(attrName, JoinType.LEFT).in(subquery);
+            rootSubquery.select(rootSubRoot.get("id")).where(rootSubPredicate);
+            return root.get("id").in(rootSubquery);
+        }
+
+        for (var i = 1; i < node.size(); i++) {
+            var child = node.get(i);
+            arguments.add(
+                processSubValue(
+                    op,
+                    child,
+                    cb,
+                    root,
+                    query,
+                    entityClass,
+                    entityClasses,
+                    throwsIfNotExistsOrNotSearchable,
+                    searchableFields,
+                    searchableCollectionTargetClasses
+                )
+            );
+        }
+        if (op.isEvaluateStrings()) {
+            return op.getExprFunction().apply(cb, arguments.toArray(new Expression[0]));
+        } else {
+            return op.getObjFunction().apply(root, (CriteriaQuery<?>) query, cb, arguments.toArray(), searchableFields);
+        }
+    }
 
     private static Expression<?> processExpression(
             JsonNode node,
@@ -155,7 +307,8 @@ public class JPASearchCore {
             Class<?> entityClass,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
-            Map<String, List<Field>> searchableFields
+            final Map<String, List<Field>> searchableFields,
+            Map<String, Class<?>> searchableCollectionTargetClasses
     ) {
         if (!node.isArray() || node.isEmpty() || !node.get(0).isTextual()) {
             throw new JPASearchException("Invalid expression");
@@ -163,22 +316,62 @@ public class JPASearchCore {
 
         var op = Operator.load(node.get(0).textValue());
         var arguments = new ArrayList<>();
+        if (op.getName().equals("has")) {
+            var attrName = node.get(1).asText();
+            var subClass = searchableCollectionTargetClasses.get(attrName);
+            Subquery subquery = query.subquery(subClass);
+            Root subRoot = subquery.from(subClass);
 
-        for (var i = 1; i < node.size(); i++) {
-            var child = node.get(i);
-            arguments.add(
-                    processValue(
-                            op,
-                            child,
-                            cb,
-                            root,
-                            query,
-                            entityClass,
-                            entityClasses,
-                            throwsIfNotExistsOrNotSearchable,
-                            searchableFields
-                    )
+            Map<String, Class<?>> subMap = searchableCollectionTargetClasses.entrySet().stream()
+                .filter(c -> c.getKey().startsWith(attrName) && c.getKey().length() > attrName.length() + 1)
+                .map(c -> {
+                    var newKey = c.getKey().substring(attrName.length() + 1);
+                    return Map.entry(newKey, c.getValue());
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            var subFields = ReflectionUtils.getAllSearchableFields(Set.of(subClass));
+            var subCriteriaBuilder = cb;
+
+            var subValue = processSubValue(
+                    op,
+                    node.get(2),
+                    subCriteriaBuilder,
+                    subRoot,
+                    subquery,
+                    subClass,
+                    entityClasses, // pass through to support nested situations
+                    throwsIfNotExistsOrNotSearchable,
+                    subFields,
+                    subMap
             );
+
+            subquery.select(subRoot).where((Predicate) subValue);
+
+            var rootSubquery = query.subquery(root.getJavaType());
+            var rootSubRoot = rootSubquery.from(root.getJavaType());
+            var rootSubPredicate = rootSubRoot.join(attrName, JoinType.LEFT).in(subquery);
+            rootSubquery.select(rootSubRoot.get("id")).where(rootSubPredicate);
+            return root.get("id").in(rootSubquery);
+
+        } else {
+            for (var i = 1; i < node.size(); i++) {
+                var child = node.get(i);
+                arguments.add(
+                    processValue(
+                        op,
+                        child,
+                        cb,
+                        root,
+                        query,
+                        entityClass,
+                        entityClasses,
+                        throwsIfNotExistsOrNotSearchable,
+                        searchableFields,
+                        searchableCollectionTargetClasses
+                    )
+                );
+            }
         }
         if (op.isEvaluateStrings()) {
             return op.getExprFunction().apply(cb, arguments.toArray(new Expression[0]));

--- a/src/main/java/com/gisgro/JPASearchCore.java
+++ b/src/main/java/com/gisgro/JPASearchCore.java
@@ -1,13 +1,13 @@
 package com.gisgro;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.gisgro.annotations.CollectionSearchable;
 import com.gisgro.annotations.Searchable;
 import com.gisgro.exceptions.InvalidFieldException;
 import com.gisgro.exceptions.JPASearchException;
 import com.gisgro.model.Operator;
 import com.gisgro.model.SearchType;
 import com.gisgro.utils.ReflectionUtils;
-import java.util.stream.Collectors;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
@@ -32,8 +32,7 @@ public class JPASearchCore {
                 filterPayload,
                 entityClass,
                 throwsIfNotExistsOrNotSearchable,
-                Collections.emptySet(),
-                Collections.emptyMap()
+                Collections.emptySet()
         );
     }
 
@@ -42,37 +41,6 @@ public class JPASearchCore {
             Class<T> entityClass,
             boolean throwsIfNotExistsOrNotSearchable,
             Set<Class<?>> searchableSubclasses
-    ) {
-        return specification(
-                filterPayload,
-                entityClass,
-                throwsIfNotExistsOrNotSearchable,
-                searchableSubclasses,
-                Collections.emptyMap()
-        );
-    }
-
-    public static <R, T> Specification<R> specification(
-        JsonNode filterPayload,
-        Class<T> entityClass,
-        boolean throwsIfNotExistsOrNotSearchable,
-        Map<String, Class<?>> searchableCollectionTargetClasses
-    ) {
-        return specification(
-            filterPayload,
-            entityClass,
-            throwsIfNotExistsOrNotSearchable,
-            Collections.emptySet(),
-            searchableCollectionTargetClasses
-        );
-    }
-
-    public static <R, T> Specification<R> specification(
-            JsonNode filterPayload,
-            Class<T> entityClass,
-            boolean throwsIfNotExistsOrNotSearchable,
-            Set<Class<?>> searchableSubclasses,
-            Map<String, Class<?>> searchableCollectionTargetClasses
     ) {
         HashSet<Class<?>> entityClasses = new HashSet<>(searchableSubclasses);
         entityClasses.add(entityClass);
@@ -89,8 +57,7 @@ public class JPASearchCore {
                     entityClass,
                     entityClasses,
                     throwsIfNotExistsOrNotSearchable,
-                    searchableFields,
-                    searchableCollectionTargetClasses
+                    searchableFields
             );
             if (expr instanceof Predicate) {
                 return (Predicate) expr;
@@ -109,8 +76,7 @@ public class JPASearchCore {
             Class<?> entityClass,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
-            Map<String, List<Field>> searchableFields,
-            Map<String, Class<?>> searchableCollectionTargetClasses
+            Map<String, List<Field>> searchableFields
     ) {
         if (node.isTextual()) {
             var text = node.asText();
@@ -144,8 +110,7 @@ public class JPASearchCore {
                     entityClass,
                     entityClasses,
                     throwsIfNotExistsOrNotSearchable,
-                    searchableFields,
-                    searchableCollectionTargetClasses
+                    searchableFields
             );
         } else if (node.isNull()) {
             return cb.nullLiteral(entityClass);
@@ -197,25 +162,19 @@ public class JPASearchCore {
             AbstractQuery<?> query,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
-            Map<String, List<Field>> searchableFields,
-            Map<String, Class<?>> searchableCollectionTargetClasses
+            Map<String, List<Field>> searchableFields
     ) {
         // First we need to do build the subquery for the collection items
         var attrName = node.get(1).asText();
-        var subClass = searchableCollectionTargetClasses.get(attrName);
+        var descriptor = loadDescriptor(attrName, throwsIfNotExistsOrNotSearchable, false, false, searchableFields);
+        if (descriptor == null) {
+            throw new JPASearchException("Invalid field for has operator: " + attrName);
+        }
+        var field = descriptor.fieldPath.get(descriptor.fieldPath.size() - 1);
+        var collectionSearchable = field.getAnnotation(CollectionSearchable.class);
+        var subClass = collectionSearchable.targetType();
         Subquery<?> subquery = query.subquery(subClass);
         Root<?> subRoot = subquery.from(subClass);
-
-        Map<String, Class<?>> subCollectionTargetClasses = searchableCollectionTargetClasses.entrySet().stream()
-            .filter(c -> {
-                var keyParts = c.getKey().split("\\.", 2);
-                return keyParts.length == 2 && keyParts[0].equals(attrName);
-            })
-            .map(c -> {
-                var newKey = c.getKey().split("\\.", 2)[1];
-                return Map.entry(newKey, c.getValue());
-            })
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         var subFields = ReflectionUtils.getAllSearchableFields(Set.of(subClass));
 
@@ -229,21 +188,15 @@ public class JPASearchCore {
                 subClass,
                 entityClasses,
                 throwsIfNotExistsOrNotSearchable,
-                subFields,
-                subCollectionTargetClasses
+                subFields
         );
 
 
         // Second we need to join the result back to root query
 
         // Join from subquery root to parent entity (not necessarily the main root, but the parent of the collection)
-        var descriptor = loadDescriptor(attrName, throwsIfNotExistsOrNotSearchable, false, false, searchableFields);
-        if (descriptor == null) {
-            throw new JPASearchException("Invalid field for has operator: " + attrName);
-        }
-        var field = descriptor.fieldPath.get(descriptor.fieldPath.size() - 1);
         var oneToMany = field.getAnnotation(OneToMany.class);
-        var backRefFieldName = oneToMany.mappedBy();
+        var backRefFieldName = collectionSearchable.mappedBy().isEmpty() ? oneToMany.mappedBy() : collectionSearchable.mappedBy();
         var join = subRoot.join(backRefFieldName, JoinType.INNER);
 
         // Handle possible nested path to get to parent entity from main root
@@ -271,8 +224,7 @@ public class JPASearchCore {
             Class<?> entityClass,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
-            Map<String, List<Field>> searchableFields,
-            Map<String, Class<?>> searchableCollectionTargetClasses
+            Map<String, List<Field>> searchableFields
     ) {
         if (!node.isArray() || node.isEmpty() || !node.get(0).isTextual()) {
             throw new JPASearchException("Invalid expression");
@@ -288,8 +240,7 @@ public class JPASearchCore {
                     query,
                     entityClasses,
                     throwsIfNotExistsOrNotSearchable,
-                    searchableFields,
-                    searchableCollectionTargetClasses
+                    searchableFields
             );
         }
         for (var i = 1; i < node.size(); i++) {
@@ -304,8 +255,7 @@ public class JPASearchCore {
                             entityClass,
                             entityClasses,
                             throwsIfNotExistsOrNotSearchable,
-                            searchableFields,
-                            searchableCollectionTargetClasses
+                            searchableFields
                     )
             );
         }
@@ -448,7 +398,12 @@ public class JPASearchCore {
         var searchable = field.getAnnotation(Searchable.class);
 
         if (searchable == null) {
-            return null;
+            var collectionSearchable = field.getAnnotation(CollectionSearchable.class);
+            if (collectionSearchable == null) {
+                return null;
+            } else {
+                return new Descriptor(SearchType.UNTYPED, path);
+            }
         }
 
         if (checkSortable && !searchable.sortable()) {

--- a/src/main/java/com/gisgro/JPASearchCore.java
+++ b/src/main/java/com/gisgro/JPASearchCore.java
@@ -8,6 +8,8 @@ import com.gisgro.model.Operator;
 import com.gisgro.model.SearchType;
 import com.gisgro.utils.ReflectionUtils;
 import java.util.stream.Collectors;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.domain.PageRequest;
@@ -194,6 +196,7 @@ public class JPASearchCore {
             AbstractQuery<?> query,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
+            Map<String, List<Field>> searchableFields,
             Map<String, Class<?>> searchableCollectionTargetClasses
     ) {
         // First we need to do build the subquery for the collection items
@@ -229,17 +232,34 @@ public class JPASearchCore {
                 subCollectionTargetClasses
         );
 
-        String rootIdFieldName = root.getModel().getId(root.getModel().getIdType().getJavaType()).getName();
-        String subIdFieldName = subRoot.getModel().getId(subRoot.getModel().getIdType().getJavaType()).getName();
 
-        subquery.select(subRoot.get(subIdFieldName)).where((Predicate) subValue);
+        // Second we need to join the result back to root query
 
-        // Then we can query the root entity for the match based on subquery results. Using a second subquery we can eliminate duplicates.
-        var rootSubquery = query.subquery(root.getJavaType());
-        var rootSubRoot = rootSubquery.from(root.getJavaType());
-        var rootSubPredicate = rootSubRoot.join(attrName, JoinType.LEFT).in(subquery);
-        rootSubquery.select(rootSubRoot.get(rootIdFieldName)).where(rootSubPredicate);
-        return root.get(rootIdFieldName).in(rootSubquery);
+        // Join from subquery root to parent entity (not necessarily the main root, but the parent of the collection)
+        var descriptor = loadDescriptor(attrName, throwsIfNotExistsOrNotSearchable, false, false, searchableFields);
+        if (descriptor == null) {
+            throw new JPASearchException("Invalid field for has operator: " + attrName);
+        }
+        var field = descriptor.fieldPath.get(descriptor.fieldPath.size() - 1);
+        var oneToMany = field.getAnnotation(OneToMany.class);
+        var backRefFieldName = oneToMany.mappedBy();
+        var join = subRoot.join(backRefFieldName, JoinType.INNER);
+
+        // Handle possible nested path to get to parent entity from main root
+        var parentPath = descriptor.fieldPath.size() > 1 ? descriptor.fieldPath.subList(0, descriptor.fieldPath.size() - 1) : null;
+        var rootParentDescriptor = parentPath != null ? new JPASearchCore.Descriptor(descriptor.searchType, parentPath) : null;
+        var rootParentExpr = rootParentDescriptor != null ? getPath(cb, root, rootParentDescriptor) : root;
+
+        // Combine rootParentExpr and subquery join on parent id field
+        var parentClass = rootParentExpr.getJavaType();
+        var parentIdFieldName = Arrays.stream(parentClass.getDeclaredFields())
+            .filter(f -> f.isAnnotationPresent(Id.class))
+            .findFirst()
+            .orElseThrow(() -> new JPASearchException("Cannot find id field for class " + parentClass.getName()))
+            .getName();
+
+        subquery.select(join.get(parentIdFieldName)).where((Predicate) subValue);
+        return rootParentExpr.in(subquery);
     }
 
     private static Expression<?> processExpression(
@@ -267,6 +287,7 @@ public class JPASearchCore {
                     query,
                     entityClasses,
                     throwsIfNotExistsOrNotSearchable,
+                    searchableFields,
                     searchableCollectionTargetClasses
             );
         }

--- a/src/main/java/com/gisgro/JPASearchCore.java
+++ b/src/main/java/com/gisgro/JPASearchCore.java
@@ -32,7 +32,8 @@ public class JPASearchCore {
                 filterPayload,
                 entityClass,
                 throwsIfNotExistsOrNotSearchable,
-                Collections.emptySet()
+                Collections.emptySet(),
+                Collections.emptyMap()
         );
     }
 

--- a/src/main/java/com/gisgro/JPASearchCore.java
+++ b/src/main/java/com/gisgro/JPASearchCore.java
@@ -50,6 +50,21 @@ public class JPASearchCore {
     }
 
     public static <R, T> Specification<R> specification(
+        JsonNode filterPayload,
+        Class<T> entityClass,
+        boolean throwsIfNotExistsOrNotSearchable,
+        Map<String, Class<?>> searchableCollectionTargetClasses
+    ) {
+        return specification(
+            filterPayload,
+            entityClass,
+            throwsIfNotExistsOrNotSearchable,
+            Collections.emptySet(),
+            searchableCollectionTargetClasses
+        );
+    }
+
+    public static <R, T> Specification<R> specification(
             JsonNode filterPayload,
             Class<T> entityClass,
             boolean throwsIfNotExistsOrNotSearchable,
@@ -81,66 +96,13 @@ public class JPASearchCore {
             }
         };
     }
-    private static <T, X> Object processSubValue(
-        Operator op,
-        JsonNode node,
-        CriteriaBuilder cb,
-        Root<T> root,
-        Subquery<X> subquery,
-        Class<?> entityClass,
-        Set<Class<?>> entityClasses,
-        boolean throwsIfNotExistsOrNotSearchable,
-        Map<String, List<Field>> searchableFields,
-        Map<String, Class<?>> searchableCollectionTargetClasses
-    ) {
-        if (node.isTextual()) {
-            var text = node.asText();
-            if (Objects.equals(op.getName(), "field")) {
-                return processField(
-                    cb,
-                    root,
-                    throwsIfNotExistsOrNotSearchable,
-                    searchableFields,
-                    text
-                );
-            } else if (!op.isEvaluateStrings()) {
-                return text;
-            } else {
-                return cb.literal(text);
-            }
-        } else if (node.isInt()) {
-            return cb.literal(node.asInt());
-        } else if (node.isLong()) {
-            return cb.literal(node.asLong());
-        } else if (node.isDouble()) {
-            return cb.literal(node.asDouble());
-        } else if (node.isBoolean()) {
-            return cb.literal(node.asBoolean());
-        } else if (node.isArray()) {
-            return processSubExpression(
-                node,
-                cb,
-                root,
-                subquery,
-                entityClass,
-                entityClasses,
-                throwsIfNotExistsOrNotSearchable,
-                searchableFields,
-                searchableCollectionTargetClasses
-            );
-        } else if (node.isNull()) {
-            return cb.nullLiteral(entityClass);
-        } else {
-            throw new JPASearchException("unexpected: " + node);
-        }
-    }
 
     private static <T> Object processValue(
             Operator op,
             JsonNode node,
             CriteriaBuilder cb,
-            Root<T> root,
-            CriteriaQuery<?> query,
+            Root<?> root,
+            AbstractQuery<?> query,
             Class<?> entityClass,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
@@ -219,95 +181,76 @@ public class JPASearchCore {
 
         return path;
     }
-    private static Expression<?> processSubExpression(
-        JsonNode node,
-        CriteriaBuilder cb,
-        Root<?> root,
-        Subquery<?> query,
-        Class<?> entityClass,
-        Set<Class<?>> entityClasses,
-        boolean throwsIfNotExistsOrNotSearchable,
-        final Map<String, List<Field>> searchableFields,
-        Map<String, Class<?>> searchableCollectionTargetClasses
+
+    /**
+     * Processes the "has" operator, which checks for the existence of related entities in a collection.
+     * This operator needs to create a subquery to check for the existence of related entities that match the specified criteria.
+     * Basic Operator handling is not sufficient for this operator, as it requires a more complex query structure involving joins and subqueries.
+     */
+    private static Expression<?> processHasOperator(
+            JsonNode node,
+            CriteriaBuilder cb,
+            Root<?> root,
+            AbstractQuery<?> query,
+            Set<Class<?>> entityClasses,
+            boolean throwsIfNotExistsOrNotSearchable,
+            Map<String, Class<?>> searchableCollectionTargetClasses
     ) {
-        if (!node.isArray() || node.isEmpty() || !node.get(0).isTextual()) {
-            throw new JPASearchException("Invalid expression");
-        }
+        // First we need to do build the subquery for the collection items
+        var attrName = node.get(1).asText();
+        var subClass = searchableCollectionTargetClasses.get(attrName);
+        Subquery<?> subquery = query.subquery(subClass);
+        Root<?> subRoot = subquery.from(subClass);
+
+        Map<String, Class<?>> subCollectionTargetClasses = searchableCollectionTargetClasses.entrySet().stream()
+            .filter(c -> {
+                var keyParts = c.getKey().split("\\.", 2);
+                return keyParts.length == 2 && keyParts[0].equals(attrName);
+            })
+            .map(c -> {
+                var newKey = c.getKey().split("\\.", 2)[1];
+                return Map.entry(newKey, c.getValue());
+            })
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        var subFields = ReflectionUtils.getAllSearchableFields(Set.of(subClass));
 
         var op = Operator.load(node.get(0).textValue());
-        var arguments = new ArrayList<>();
-        if (op.getName().equals("has")) {
-            var attrName = node.get(1).asText();
-            var subClass = searchableCollectionTargetClasses.get(attrName);
-            Subquery subquery = query.subquery(subClass);
-            Root subRoot = subquery.from(subClass);
+        var subValue = processValue(
+                op,
+                node.get(2),
+                cb,
+                subRoot,
+                subquery,
+                subClass,
+                entityClasses,
+                throwsIfNotExistsOrNotSearchable,
+                subFields,
+                subCollectionTargetClasses
+        );
 
-            Map<String, Class<?>> subMap = searchableCollectionTargetClasses.entrySet().stream()
-                .filter(c -> c.getKey().startsWith(attrName) && c.getKey().length() > attrName.length() + 1)
-                .map(c -> {
-                    var newKey = c.getKey().substring(attrName.length() + 1);
-                    return Map.entry(newKey, c.getValue());
-                })
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        String rootIdFieldName = root.getModel().getId(root.getModel().getIdType().getJavaType()).getName();
+        String subIdFieldName = subRoot.getModel().getId(subRoot.getModel().getIdType().getJavaType()).getName();
 
-            var subFields = ReflectionUtils.getAllSearchableFields(Set.of(subClass));
-            var subCriteriaBuilder = cb;
+        subquery.select(subRoot.get(subIdFieldName)).where((Predicate) subValue);
 
-            var subValue = processSubValue(
-                    op,
-                    node.get(2),
-                    subCriteriaBuilder,
-                    subRoot,
-                    subquery,
-                    subClass,
-                    entityClasses, // pass through to support nested situations
-                    throwsIfNotExistsOrNotSearchable,
-                    subFields,
-                    subMap
-            );
-
-            subquery.select(subRoot).where((Predicate) subValue);
-
-            var rootSubquery = query.subquery(root.getJavaType());
-            var rootSubRoot = rootSubquery.from(root.getJavaType());
-            var rootSubPredicate = rootSubRoot.join(attrName, JoinType.LEFT).in(subquery);
-            rootSubquery.select(rootSubRoot.get("id")).where(rootSubPredicate);
-            return root.get("id").in(rootSubquery);
-        }
-
-        for (var i = 1; i < node.size(); i++) {
-            var child = node.get(i);
-            arguments.add(
-                processSubValue(
-                    op,
-                    child,
-                    cb,
-                    root,
-                    query,
-                    entityClass,
-                    entityClasses,
-                    throwsIfNotExistsOrNotSearchable,
-                    searchableFields,
-                    searchableCollectionTargetClasses
-                )
-            );
-        }
-        if (op.isEvaluateStrings()) {
-            return op.getExprFunction().apply(cb, arguments.toArray(new Expression[0]));
-        } else {
-            return op.getObjFunction().apply(root, (CriteriaQuery<?>) query, cb, arguments.toArray(), searchableFields);
-        }
+        // Then we can query the root entity for the match based on subquery results. Using a second subquery we can eliminate duplicates.
+        var rootSubquery = query.subquery(root.getJavaType());
+        var rootSubRoot = rootSubquery.from(root.getJavaType());
+        var rootSubPredicate = rootSubRoot.join(attrName, JoinType.LEFT).in(subquery);
+        rootSubquery.select(rootSubRoot.get(rootIdFieldName)).where(rootSubPredicate);
+        return root.get(rootIdFieldName).in(rootSubquery);
     }
 
     private static Expression<?> processExpression(
             JsonNode node,
             CriteriaBuilder cb,
             Root<?> root,
-            CriteriaQuery<?> query,
+            AbstractQuery<?> query,
             Class<?> entityClass,
             Set<Class<?>> entityClasses,
             boolean throwsIfNotExistsOrNotSearchable,
-            final Map<String, List<Field>> searchableFields,
+            Map<String, List<Field>> searchableFields,
             Map<String, Class<?>> searchableCollectionTargetClasses
     ) {
         if (!node.isArray() || node.isEmpty() || !node.get(0).isTextual()) {
@@ -317,61 +260,32 @@ public class JPASearchCore {
         var op = Operator.load(node.get(0).textValue());
         var arguments = new ArrayList<>();
         if (op.getName().equals("has")) {
-            var attrName = node.get(1).asText();
-            var subClass = searchableCollectionTargetClasses.get(attrName);
-            Subquery subquery = query.subquery(subClass);
-            Root subRoot = subquery.from(subClass);
-
-            Map<String, Class<?>> subMap = searchableCollectionTargetClasses.entrySet().stream()
-                .filter(c -> c.getKey().startsWith(attrName) && c.getKey().length() > attrName.length() + 1)
-                .map(c -> {
-                    var newKey = c.getKey().substring(attrName.length() + 1);
-                    return Map.entry(newKey, c.getValue());
-                })
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-            var subFields = ReflectionUtils.getAllSearchableFields(Set.of(subClass));
-            var subCriteriaBuilder = cb;
-
-            var subValue = processSubValue(
-                    op,
-                    node.get(2),
-                    subCriteriaBuilder,
-                    subRoot,
-                    subquery,
-                    subClass,
-                    entityClasses, // pass through to support nested situations
+            return processHasOperator(
+                    node,
+                    cb,
+                    root,
+                    query,
+                    entityClasses,
                     throwsIfNotExistsOrNotSearchable,
-                    subFields,
-                    subMap
+                    searchableCollectionTargetClasses
             );
-
-            subquery.select(subRoot).where((Predicate) subValue);
-
-            var rootSubquery = query.subquery(root.getJavaType());
-            var rootSubRoot = rootSubquery.from(root.getJavaType());
-            var rootSubPredicate = rootSubRoot.join(attrName, JoinType.LEFT).in(subquery);
-            rootSubquery.select(rootSubRoot.get("id")).where(rootSubPredicate);
-            return root.get("id").in(rootSubquery);
-
-        } else {
-            for (var i = 1; i < node.size(); i++) {
-                var child = node.get(i);
-                arguments.add(
+        }
+        for (var i = 1; i < node.size(); i++) {
+            var child = node.get(i);
+            arguments.add(
                     processValue(
-                        op,
-                        child,
-                        cb,
-                        root,
-                        query,
-                        entityClass,
-                        entityClasses,
-                        throwsIfNotExistsOrNotSearchable,
-                        searchableFields,
-                        searchableCollectionTargetClasses
+                            op,
+                            child,
+                            cb,
+                            root,
+                            query,
+                            entityClass,
+                            entityClasses,
+                            throwsIfNotExistsOrNotSearchable,
+                            searchableFields,
+                            searchableCollectionTargetClasses
                     )
-                );
-            }
+            );
         }
         if (op.isEvaluateStrings()) {
             return op.getExprFunction().apply(cb, arguments.toArray(new Expression[0]));

--- a/src/main/java/com/gisgro/JPASearchFunctions.java
+++ b/src/main/java/com/gisgro/JPASearchFunctions.java
@@ -76,6 +76,11 @@ public class JPASearchFunctions {
         throw new JPASearchException(String.format("Cannot find enum %s", className));
     };
 
+    public static final JPAFuncWithExpressions<?, ?> HAS = (cb, values) -> {
+        // no-op, handled in processValue.
+        return values[0];
+    };
+
     public static <Z, X> Expression<Z> getPath(
             CriteriaBuilder cb,
             Root<X> root,

--- a/src/main/java/com/gisgro/JPASearchFunctions.java
+++ b/src/main/java/com/gisgro/JPASearchFunctions.java
@@ -76,10 +76,7 @@ public class JPASearchFunctions {
         throw new JPASearchException(String.format("Cannot find enum %s", className));
     };
 
-    public static final JPAFuncWithExpressions<?, ?> HAS = (cb, values) -> {
-        // no-op, handled in processValue.
-        return values[0];
-    };
+    public static final JPAFuncWithExpressions<?, ?> HAS = (cb, values) -> values[0]; // no-op, handled in processExpression
 
     public static <Z, X> Expression<Z> getPath(
             CriteriaBuilder cb,

--- a/src/main/java/com/gisgro/annotations/CollectionSearchable.java
+++ b/src/main/java/com/gisgro/annotations/CollectionSearchable.java
@@ -1,0 +1,21 @@
+package com.gisgro.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for collection fields that should be included in search criteria.
+ * The 'mappedBy' attribute is optional when using @OneToMany with mappedBy
+ * and can be used to specify the owning side of the relationship.
+ * The 'targetType' attribute is required to specify the type of elements in the collection.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface CollectionSearchable {
+
+  String mappedBy() default "";
+  Class<?> targetType();
+
+}

--- a/src/main/java/com/gisgro/model/Operator.java
+++ b/src/main/java/com/gisgro/model/Operator.java
@@ -53,7 +53,8 @@ public class Operator {
                 new Operator("bigDecimal", JPASearchFunctions.BIG_DECIMAL),
                 new Operator("period", JPASearchFunctions.PERIOD),
                 new Operator("isNull", JPASearchFunctions.NULL),
-                new Operator("isEmpty", JPASearchFunctions.EMPTY)
+                new Operator("isEmpty", JPASearchFunctions.EMPTY),
+                new Operator("has", JPASearchFunctions.HAS)
         };
         for (Operator operator : operatorArray) {
             operators.put(operator.getName(), operator);

--- a/src/main/java/com/gisgro/utils/JPAFuncWithObjects.java
+++ b/src/main/java/com/gisgro/utils/JPAFuncWithObjects.java
@@ -1,7 +1,7 @@
 package com.gisgro.utils;
 
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.AbstractQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 import java.lang.reflect.Field;
@@ -9,5 +9,5 @@ import java.util.List;
 import java.util.Map;
 
 public interface JPAFuncWithObjects<V> {
-    Expression<V> apply(Root<?> r, CriteriaQuery<?> query, CriteriaBuilder cb, Object[] u, Map<String, List<Field>> s);
+    Expression<V> apply(Root<?> r, AbstractQuery<?> query, CriteriaBuilder cb, Object[] u, Map<String, List<Field>> s);
 }

--- a/src/main/java/com/gisgro/utils/ReflectionUtils.java
+++ b/src/main/java/com/gisgro/utils/ReflectionUtils.java
@@ -1,5 +1,6 @@
 package com.gisgro.utils;
 
+import com.gisgro.annotations.CollectionSearchable;
 import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
 import com.gisgro.exceptions.JPASearchException;
@@ -17,7 +18,8 @@ public class ReflectionUtils {
                 entityClasses,
                 new ArrayList<>(),
                 new HashMap<>(),
-                true
+                true,
+                Collections.emptySet()
         );
     }
 
@@ -25,7 +27,8 @@ public class ReflectionUtils {
             Set<Class<?>> entityClasses,
             List<Field> path,
             Map<String, List<Field>> res,
-            boolean evaluateNested
+            boolean evaluateNested,
+            Set<Class<?>> visitedClasses
     ) {
         var fields = new HashSet<Field>();
 
@@ -37,7 +40,7 @@ public class ReflectionUtils {
             var newPath = new ArrayList<>(path);
             newPath.add(f);
 
-            if (f.isAnnotationPresent(Searchable.class)) {
+            if (f.isAnnotationPresent(Searchable.class) || f.isAnnotationPresent(CollectionSearchable.class)) {
                 res.putIfAbsent(
                         newPath
                                 .stream()
@@ -46,13 +49,28 @@ public class ReflectionUtils {
                         newPath
                 );
             }
+            if (evaluateNested && f.isAnnotationPresent(CollectionSearchable.class)) {
+                var type = getType(f);
+                var _visitedClasses = new HashSet<>(visitedClasses);
+                _visitedClasses.add(type);
+                getAllSearchableFields(
+                    Set.of(type),
+                    new ArrayList<>(),
+                    res,
+                    !entityClasses.contains(type),
+                    _visitedClasses
+                );
+            }
             if (evaluateNested && f.isAnnotationPresent(NestedSearchable.class)) {
                 var type = getType(f);
+                var _visitedClasses = new HashSet<>(visitedClasses);
+                _visitedClasses.add(type);
                 getAllSearchableFields(
                         Set.of(type),
                         newPath,
                         res,
-                        !entityClasses.contains(type)
+                        !entityClasses.contains(type),
+                        _visitedClasses
                 );
             }
         });

--- a/src/main/java/com/gisgro/utils/ReflectionUtils.java
+++ b/src/main/java/com/gisgro/utils/ReflectionUtils.java
@@ -19,7 +19,8 @@ public class ReflectionUtils {
                 new ArrayList<>(),
                 new HashMap<>(),
                 true,
-                Collections.emptySet()
+                Collections.emptySet(),
+                0
         );
     }
 
@@ -28,7 +29,8 @@ public class ReflectionUtils {
             List<Field> path,
             Map<String, List<Field>> res,
             boolean evaluateNested,
-            Set<Class<?>> visitedClasses
+            Set<Class<?>> visitedClasses,
+            int circularReferencesDepth
     ) {
         var fields = new HashSet<Field>();
 
@@ -49,30 +51,25 @@ public class ReflectionUtils {
                         newPath
                 );
             }
-            if (evaluateNested && f.isAnnotationPresent(CollectionSearchable.class)) {
+            var isCollectionSearchable = f.isAnnotationPresent(CollectionSearchable.class);
+            var isNestedSearchable = f.isAnnotationPresent(NestedSearchable.class);
+
+            if (evaluateNested && (isCollectionSearchable || isNestedSearchable)) {
                 var type = getType(f);
+                var _circularReferencesDepth = visitedClasses.contains(type) ? circularReferencesDepth - 1 : circularReferencesDepth;
+                var _evaluateNested = !entityClasses.contains(type) && _circularReferencesDepth >= 0;
                 var _visitedClasses = new HashSet<>(visitedClasses);
                 _visitedClasses.add(type);
                 getAllSearchableFields(
                     Set.of(type),
-                    new ArrayList<>(),
+                    isNestedSearchable ? newPath : new ArrayList<>(),
                     res,
-                    !entityClasses.contains(type),
-                    _visitedClasses
+                    _evaluateNested,
+                    _visitedClasses,
+                    _circularReferencesDepth
                 );
             }
-            if (evaluateNested && f.isAnnotationPresent(NestedSearchable.class)) {
-                var type = getType(f);
-                var _visitedClasses = new HashSet<>(visitedClasses);
-                _visitedClasses.add(type);
-                getAllSearchableFields(
-                        Set.of(type),
-                        newPath,
-                        res,
-                        !entityClasses.contains(type),
-                        _visitedClasses
-                );
-            }
+
         });
 
         return res;

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -199,12 +199,14 @@ public class JpaSearchTests {
     private void setup5() {
         var entity = setup();
         var entity5 = new TestEntity5();
+        entity5.setEntity1(entity);
         testEntity5Repository.save(entity5);
         entity.setEntity5(entity5);
         testEntityRepository.save(entity);
         List<TestEntity> nestedList = new ArrayList<>();
         nestedList.add(entity);
         entity5.setNestedList(nestedList);
+        entity5.setEntity1(entity);
         testEntity5Repository.save(entity5);
     }
 
@@ -850,7 +852,7 @@ public class JpaSearchTests {
         setup5();
         var filterString = """
                 {
-                 "filter": ["has", "nestedList", ["and", ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]]]
+                 "filter": ["has", "nestedList", ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]]]
                 }
                 """;
 
@@ -865,7 +867,7 @@ public class JpaSearchTests {
         // Filter for TestEntity5 that has a nestedList item for which at least one nestedSet items does not contain string "nestedSet"
         var filterString = """
                 {
-                 "filter": ["has", "nestedList", ["and", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet"]]]]]]
+                 "filter": ["has", "nestedList", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet"]]]]]
                 }
                 """;
 
@@ -876,7 +878,7 @@ public class JpaSearchTests {
         // Filter for TestEntity5 that has a nestedList item for which at least one nestedSet items does not contain string "nestedSet0"
         var filterString2 = """
                 {
-                 "filter": ["has", "nestedList", ["and", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet0"]]]]]]
+                 "filter": ["has", "nestedList", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet0"]]]]]
                 }
                 """;
 
@@ -891,7 +893,7 @@ public class JpaSearchTests {
         // Filter for TestEntity5 that has a nestedList item for which none of the nestedSet items have string equal to "nestedSet0"
         var filterString = """
                 {
-                 "filter": ["has", "nestedList", ["and", ["not", ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]]]]
+                 "filter": ["has", "nestedList", ["not", ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]]]
                 }
                 """;
 
@@ -902,12 +904,27 @@ public class JpaSearchTests {
         // Filter for TestEntity5 that has a nestedList item for which none of the nestedSet items have string that is null
         var filterString2 = """
                 {
-                 "filter": ["has", "nestedList", ["and", ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]]]
+                 "filter": ["has", "nestedList", ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]]
                 }
                 """;
 
         List<TestEntity5> result2 = testEntity5Repository.findAll(specificationFrom(filterString2, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
 
         assertThat(result2).hasSize(1);
+    }
+
+    @Test
+    public void testHasWithNestedField() {
+        setup5();
+
+        var filterString = """
+                {
+                 "filter": ["has", "entity1.nestedSet", ["contains", ["field", "string"], "nestedSet"]]
+                }
+                """;
+
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("entity1.nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
     }
 }

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -246,21 +246,6 @@ public class JpaSearchTests {
         );
     }
 
-    @SneakyThrows
-    private <T> Specification<T> specificationFrom(
-        String filterString,
-        Class<T> clazz,
-        Map<String,Class<?>> searchableCollectionClasses
-    ) {
-        JsonNode filters = mapper.readTree(filterString);
-        return JPASearchCore.specification(
-            filters,
-            clazz,
-            true,
-            searchableCollectionClasses
-        );
-    }
-
     private <T> PageRequest pageRequestFrom(String filterString, Class<T> clazz) {
         return pageRequestFrom(filterString, clazz, Collections.emptySet());
     }
@@ -775,7 +760,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(1);
     }
@@ -792,7 +777,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(0);
     }
@@ -809,7 +794,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(1);
     }
@@ -823,7 +808,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(1);
     }
@@ -837,7 +822,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(0);
 
@@ -860,7 +845,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(1);
     }
@@ -874,7 +859,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class));
 
         assertThat(result).hasSize(1);
     }
@@ -889,7 +874,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class));
 
         assertThat(result).hasSize(1);
     }
@@ -905,10 +890,7 @@ public class JpaSearchTests {
                 }
                 """, searchString);
 
-            List<TestEntity5> result = testEntity5Repository.findAll(
-                specificationFrom(filterString, TestEntity5.class,
-                    Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class))
-            );
+            List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class));
             assertThat(result).hasSize(expectedSize);
         };
 
@@ -926,7 +908,7 @@ public class JpaSearchTests {
                 }
                 """;
 
-        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("entity1.nestedSet", TestEntity2.class)));
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class));
 
         assertThat(result).hasSize(1);
     }

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gisgro.model.Operator;
 import com.gisgro.utils.JPAFuncWithObjects;
+import java.util.function.BiConsumer;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -770,14 +771,47 @@ public class JpaSearchTests {
         setup();
         var filterString = """
                 {
-                 "filter": ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]
+                 "filter": ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]]
                 }
                 """;
 
         List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
 
         assertThat(result).hasSize(1);
-        System.out.println(result.get(0).getNestedSet().stream().map(TestEntity2::getString).reduce((a, b) -> a + ", " + b).orElse(""));
+    }
+
+    @Test
+    public void testNestedSetEqualAndEqual() {
+        setup();
+        // This filter looks for TestEntity that has a nestedSet item with string equal to "nestedSet0" AND string equal to "nestedSet1"
+        var filterString = """
+                {
+                 "filter": ["has", "nestedSet", ["and",
+                   ["eq", ["field", "string"], "nestedSet0"],
+                   ["eq", ["field", "string"], "nestedSet1"]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void testNestedSetEqualAndNestedSetEqual() {
+        setup();
+        // This filter looks for TestEntity that has a nestedSet item with string equal to "nestedSet0" and another nestedSet item with string equal to "nestedSet1"
+        var filterString = """
+                {
+                 "filter": ["and",
+                   ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]],
+                   ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet1"]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
     }
 
     @Test
@@ -785,15 +819,13 @@ public class JpaSearchTests {
         setup();
         var filterString = """
                 {
-                 "filter": ["has", "nestedSet", ["and", ["contains", ["field", "string"], "nested"]]]
+                 "filter": ["has", "nestedSet", ["contains", ["field", "string"], "nested"]]
                 }
                 """;
 
         List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
 
         assertThat(result).hasSize(1);
-        System.out.println("RESULTSTRINGS:"+result.get(0).getNestedSet().stream().map(TestEntity2::getString).reduce((a, b) -> a + ", " + b).orElse(""));
-        System.out.println("RESULTIDS:"+result.stream().map(e -> e.getId().toString()).reduce((a, b) -> a + ", " + b).orElse(""));
     }
 
     @Test
@@ -801,7 +833,7 @@ public class JpaSearchTests {
         setup();
         var filterString = """
                 {
-                 "filter": ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]
+                 "filter": ["has", "nestedSet", ["isNull", ["field", "string"]]]
                 }
                 """;
 
@@ -811,7 +843,7 @@ public class JpaSearchTests {
 
         var filterString2 = """
                 {
-                 "filter": ["and", ["isNull", ["field", "string"]]]
+                 "filter": ["isNull", ["field", "string"]]
                 }
                 """;
         List<TestEntity2> result2 = testEntity2Repository.findAll(specificationFrom(filterString2, TestEntity2.class));
@@ -824,7 +856,7 @@ public class JpaSearchTests {
         setup();
         var filterString = """
                 {
-                 "filter": ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]
+                 "filter": ["not", ["has", "nestedSet", ["isNull", ["field", "string"]]]]
                 }
                 """;
 
@@ -838,7 +870,7 @@ public class JpaSearchTests {
         setup();
         var filterString = """
                 {
-                 "filter": ["has", "nestedSet", ["and", ["not", ["isNull", ["field", "string"]]]]]
+                 "filter": ["has", "nestedSet", ["not", ["isNull", ["field", "string"]]]]
                 }
                 """;
 
@@ -852,7 +884,8 @@ public class JpaSearchTests {
         setup5();
         var filterString = """
                 {
-                 "filter": ["has", "nestedList", ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]]]
+                 "filter": ["has", "nestedList",
+                   ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]]]
                 }
                 """;
 
@@ -864,53 +897,23 @@ public class JpaSearchTests {
     @Test
     public void testDoublyNestedSetNot() {
         setup5();
-        // Filter for TestEntity5 that has a nestedList item for which at least one nestedSet items does not contain string "nestedSet"
-        var filterString = """
+        BiConsumer<String, Integer> runTest = (searchString, expectedSize) -> {
+            String filterString = String.format("""
                 {
-                 "filter": ["has", "nestedList", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet"]]]]]
+                 "filter": ["has", "nestedList",
+                   ["has", "nestedSet", ["not", ["contains", ["field", "string"], "%s"]]]]
                 }
-                """;
+                """, searchString);
 
-        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+            List<TestEntity5> result = testEntity5Repository.findAll(
+                specificationFrom(filterString, TestEntity5.class,
+                    Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class))
+            );
+            assertThat(result).hasSize(expectedSize);
+        };
 
-        assertThat(result).hasSize(0);
-
-        // Filter for TestEntity5 that has a nestedList item for which at least one nestedSet items does not contain string "nestedSet0"
-        var filterString2 = """
-                {
-                 "filter": ["has", "nestedList", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet0"]]]]]
-                }
-                """;
-
-        List<TestEntity5> result2 = testEntity5Repository.findAll(specificationFrom(filterString2, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
-
-        assertThat(result2).hasSize(1);
-    }
-
-    @Test
-    public void testDoublyNestedSetNotHamburger() {
-        setup5();
-        // Filter for TestEntity5 that has a nestedList item for which none of the nestedSet items have string equal to "nestedSet0"
-        var filterString = """
-                {
-                 "filter": ["has", "nestedList", ["not", ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]]]
-                }
-                """;
-
-        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
-
-        assertThat(result).hasSize(0);
-
-        // Filter for TestEntity5 that has a nestedList item for which none of the nestedSet items have string that is null
-        var filterString2 = """
-                {
-                 "filter": ["has", "nestedList", ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]]
-                }
-                """;
-
-        List<TestEntity5> result2 = testEntity5Repository.findAll(specificationFrom(filterString2, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
-
-        assertThat(result2).hasSize(1);
+        runTest.accept("nestedSet", 0);
+        runTest.accept("nestedSet0", 1);
     }
 
     @Test

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -783,6 +783,39 @@ public class JpaSearchTests {
     }
 
     @Test
+    public void testNestedSetEqualAndEqual2() {
+        setup5();
+        // This filter looks for TestEntity that has a nestedSet item with string equal to "nestedSet0" AND string equal to "nestedSet1"
+        var filterString = """
+                {
+                 "filter": ["has", "nestedList", ["and",
+                   ["eq", ["field", "email"], "test@test.fi"],
+                   ["eq", ["field", "dateString"], "20240609"]]]
+                }
+                """;
+
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class));
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void testNestedSetEqualOrEqual() {
+        setup5();
+        // This filter looks for TestEntity that has a nestedSet item with string equal to "nestedSet0" AND string equal to "nestedSet1"
+        var filterString = """
+                {
+                 "filter": ["has", "nestedList", ["or",
+                   ["eq", ["field", "email"], "t@t.fi"],
+                   ["eq", ["field", "dateString"], "20240609"]]]
+                }
+                """;
+
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class));
+
+        assertThat(result).hasSize(1);
+    }
+    @Test
     public void testNestedSetEqualAndNestedSetEqual() {
         setup();
         // This filter looks for TestEntity that has a nestedSet item with string equal to "nestedSet0" and another nestedSet item with string equal to "nestedSet1"

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -43,19 +43,21 @@ public class JpaSearchTests {
     @Autowired
     private TestEntity4Repository testEntity4Repository;
     @Autowired
+    private TestEntity5Repository testEntity5Repository;
+    @Autowired
     private ParentEntityRepository parentEntityRepository;
     @Autowired
     private TestCategoryRepository testCategoryRepository;
     @Autowired
     private TestEntityWithCategoryRepository testEntityWithCategoryRepository;
 
-    private void setup() {
+    private TestEntity setup() {
         var ent2 = new TestEntity2(
                 0L,
                 "Nested! daa dumdidum"
         );
-
         ent2 = testEntity2Repository.save(ent2);
+        // Create TestEntity first
         TestEntity ent = new TestEntity(
                 0L,
                 6,
@@ -82,10 +84,28 @@ public class JpaSearchTests {
                 false,
                 true,
                 ent2,
+                new HashSet<>(),
                 TestEnum.VALUE1,
-                Period.parse("P6M")
+                Period.parse("P6M"),
+                null
         );
-        testEntityRepository.save(ent);
+        ent = testEntityRepository.save(ent);
+        // Now create set0 and set1, set their parent to ent
+        var set0 = new TestEntity2(
+                0L,
+                "nestedSet0",
+                ent
+        );
+        set0 = testEntity2Repository.save(set0);
+        var set1 = new TestEntity2(
+                0L,
+                "nestedSet1",
+                ent
+        );
+        set1 = testEntity2Repository.save(set1);
+        // Update ent's nestedSet and save again
+        ent.setNestedSet(new HashSet<>(Arrays.asList(set0, set1)));
+        return testEntityRepository.save(ent);
     }
 
     private void setup2() {
@@ -126,8 +146,10 @@ public class JpaSearchTests {
                 false,
                 true,
                 ent2a,
+                Collections.emptySet(),
                 TestEnum.VALUE1,
-                Period.parse("P12M")
+                Period.parse("P12M"),
+                null
         );
         testEntityRepository.save(ent);
         ent = new TestEntity(
@@ -156,8 +178,10 @@ public class JpaSearchTests {
                 false,
                 true,
                 ent2b,
+                Collections.emptySet(),
                 TestEnum.VALUE2,
-                Period.parse("P6M")
+                Period.parse("P6M"),
+                null
         );
         testEntityRepository.save(ent);
     }
@@ -170,6 +194,18 @@ public class JpaSearchTests {
     private void setup4() {
         var foo = testEntity4Repository.save(new TestEntity4(0L, "parentFoo", "foo", null));
         testEntity4Repository.save(new TestEntity4(0L, "parentBar", "bar", foo));
+    }
+
+    private void setup5() {
+        var entity = setup();
+        var entity5 = new TestEntity5();
+        testEntity5Repository.save(entity5);
+        entity.setEntity5(entity5);
+        testEntityRepository.save(entity);
+        List<TestEntity> nestedList = new ArrayList<>();
+        nestedList.add(entity);
+        entity5.setNestedList(nestedList);
+        testEntity5Repository.save(entity5);
     }
 
     private void setupMappedSuperclass() {
@@ -204,6 +240,22 @@ public class JpaSearchTests {
                 clazz,
                 true,
                 searchableSubclasses
+        );
+    }
+
+    @SneakyThrows
+    private <T> Specification<T> specificationFrom(
+        String filterString,
+        Class<T> clazz,
+        Map<String,Class<?>> searchableCollectionClasses
+    ) {
+        JsonNode filters = mapper.readTree(filterString);
+        return JPASearchCore.specification(
+            filters,
+            clazz,
+            true,
+            Collections.emptySet(),
+            searchableCollectionClasses
         );
     }
 
@@ -710,5 +762,87 @@ public class JpaSearchTests {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getTitle()).isEqualTo("Contract A");
         assertThat(result.get(0).getCategory().getDescription()).contains("rental");
+    }
+
+    @Test
+    public void testNestedSetEqual() {
+        setup();
+        var filterString = """
+                {
+                 "filter": ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
+        System.out.println(result.get(0).getNestedSet().stream().map(TestEntity2::getString).reduce((a, b) -> a + ", " + b).orElse(""));
+    }
+
+    @Test
+    public void testNestedSetContains() {
+        setup();
+        var filterString = """
+                {
+                 "filter": ["has", "nestedSet", ["and", ["contains", ["field", "string"], "nested"]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
+        System.out.println("RESULTSTRINGS:"+result.get(0).getNestedSet().stream().map(TestEntity2::getString).reduce((a, b) -> a + ", " + b).orElse(""));
+        System.out.println("RESULTIDS:"+result.stream().map(e -> e.getId().toString()).reduce((a, b) -> a + ", " + b).orElse(""));
+    }
+
+    @Test
+    public void testNestedSetIsNull() {
+        setup();
+        var filterString = """
+                {
+                 "filter": ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(0);
+
+        var filterString2 = """
+                {
+                 "filter": ["and", ["isNull", ["field", "string"]]]
+                }
+                """;
+        List<TestEntity2> result2 = testEntity2Repository.findAll(specificationFrom(filterString2, TestEntity2.class));
+
+        assertThat(result2).hasSize(0);
+    }
+
+    @Test
+    public void testNestedSetEmpty() {
+        setup();
+        var filterString = """
+                {
+                 "filter": ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void testDoublyNestedSetEqual() {
+        setup5();
+        var filterString = """
+                {
+                 "filter": ["has", "nestedList", ["and", ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]]]
+                }
+                """;
+
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
     }
 }

--- a/src/test/java/com/gisgro/JpaSearchTests.java
+++ b/src/test/java/com/gisgro/JpaSearchTests.java
@@ -254,7 +254,6 @@ public class JpaSearchTests {
             filters,
             clazz,
             true,
-            Collections.emptySet(),
             searchableCollectionClasses
         );
     }
@@ -819,11 +818,25 @@ public class JpaSearchTests {
     }
 
     @Test
-    public void testNestedSetEmpty() {
+    public void testNestedSetWithoutMatch() {
         setup();
         var filterString = """
                 {
                  "filter": ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]
+                }
+                """;
+
+        List<TestEntity> result = testEntityRepository.findAll(specificationFrom(filterString, TestEntity.class, Map.of("nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void testNestedSetNot() {
+        setup();
+        var filterString = """
+                {
+                 "filter": ["has", "nestedSet", ["and", ["not", ["isNull", ["field", "string"]]]]]
                 }
                 """;
 
@@ -844,5 +857,57 @@ public class JpaSearchTests {
         List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
 
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void testDoublyNestedSetNot() {
+        setup5();
+        // Filter for TestEntity5 that has a nestedList item for which at least one nestedSet items does not contain string "nestedSet"
+        var filterString = """
+                {
+                 "filter": ["has", "nestedList", ["and", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet"]]]]]]
+                }
+                """;
+
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(0);
+
+        // Filter for TestEntity5 that has a nestedList item for which at least one nestedSet items does not contain string "nestedSet0"
+        var filterString2 = """
+                {
+                 "filter": ["has", "nestedList", ["and", ["has", "nestedSet", ["and", ["not", ["contains", ["field", "string"], "nestedSet0"]]]]]]
+                }
+                """;
+
+        List<TestEntity5> result2 = testEntity5Repository.findAll(specificationFrom(filterString2, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+
+        assertThat(result2).hasSize(1);
+    }
+
+    @Test
+    public void testDoublyNestedSetNotHamburger() {
+        setup5();
+        // Filter for TestEntity5 that has a nestedList item for which none of the nestedSet items have string equal to "nestedSet0"
+        var filterString = """
+                {
+                 "filter": ["has", "nestedList", ["and", ["not", ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"]]]]]]
+                }
+                """;
+
+        List<TestEntity5> result = testEntity5Repository.findAll(specificationFrom(filterString, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+
+        assertThat(result).hasSize(0);
+
+        // Filter for TestEntity5 that has a nestedList item for which none of the nestedSet items have string that is null
+        var filterString2 = """
+                {
+                 "filter": ["has", "nestedList", ["and", ["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]]]
+                }
+                """;
+
+        List<TestEntity5> result2 = testEntity5Repository.findAll(specificationFrom(filterString2, TestEntity5.class, Map.of("nestedList", TestEntity.class, "nestedList.nestedSet", TestEntity2.class)));
+
+        assertThat(result2).hasSize(1);
     }
 }

--- a/src/test/java/com/gisgro/TestEntity.java
+++ b/src/test/java/com/gisgro/TestEntity.java
@@ -3,6 +3,7 @@ package com.gisgro;
 import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
 import com.gisgro.model.SearchType;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -100,8 +101,15 @@ public class TestEntity {
     private TestEntity2 nested;
 
     @Searchable
+    @OneToMany(mappedBy = "entity1")
+    private Set<TestEntity2> nestedSet;
+
+    @Searchable
     private TestEnum testEnum;
 
     @Searchable
     private Period period;
+
+    @ManyToOne
+    private TestEntity5 entity5;
 }

--- a/src/test/java/com/gisgro/TestEntity.java
+++ b/src/test/java/com/gisgro/TestEntity.java
@@ -1,5 +1,6 @@
 package com.gisgro;
 
+import com.gisgro.annotations.CollectionSearchable;
 import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
 import com.gisgro.model.SearchType;
@@ -100,7 +101,7 @@ public class TestEntity {
     @JoinColumn
     private TestEntity2 nested;
 
-    @Searchable
+    @CollectionSearchable(targetType = TestEntity2.class, mappedBy = "entity1")
     @OneToMany(mappedBy = "entity1")
     private Set<TestEntity2> nestedSet;
 

--- a/src/test/java/com/gisgro/TestEntity2.java
+++ b/src/test/java/com/gisgro/TestEntity2.java
@@ -1,6 +1,7 @@
 package com.gisgro;
 
 import com.gisgro.annotations.Searchable;
+import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,4 +26,13 @@ public class TestEntity2 {
 
     @Searchable
     private String string;
+
+    @ManyToOne
+    private TestEntity entity1;
+
+    public TestEntity2(Long id, String string) {
+        this.id = id;
+        this.string = string;
+        this.entity1 = null;
+    }
 }

--- a/src/test/java/com/gisgro/TestEntity5.java
+++ b/src/test/java/com/gisgro/TestEntity5.java
@@ -1,5 +1,6 @@
 package com.gisgro;
 
+import com.gisgro.annotations.CollectionSearchable;
 import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
 import java.util.ArrayList;
@@ -25,12 +26,11 @@ public class TestEntity5 {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Searchable
+  @CollectionSearchable(targetType = TestEntity.class)
   @OneToMany(mappedBy = "entity5")
   private List<TestEntity> nestedList = new ArrayList<>();
 
   @NestedSearchable
-  @Searchable
   @ManyToOne
   private TestEntity entity1;
 

--- a/src/test/java/com/gisgro/TestEntity5.java
+++ b/src/test/java/com/gisgro/TestEntity5.java
@@ -2,7 +2,6 @@ package com.gisgro;
 
 import com.gisgro.annotations.CollectionSearchable;
 import com.gisgro.annotations.NestedSearchable;
-import com.gisgro.annotations.Searchable;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Entity;

--- a/src/test/java/com/gisgro/TestEntity5.java
+++ b/src/test/java/com/gisgro/TestEntity5.java
@@ -1,5 +1,6 @@
 package com.gisgro;
 
+import com.gisgro.annotations.NestedSearchable;
 import com.gisgro.annotations.Searchable;
 import java.util.ArrayList;
 import java.util.List;
@@ -7,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,5 +28,10 @@ public class TestEntity5 {
   @Searchable
   @OneToMany(mappedBy = "entity5")
   private List<TestEntity> nestedList = new ArrayList<>();
+
+  @NestedSearchable
+  @Searchable
+  @ManyToOne
+  private TestEntity entity1;
 
 }

--- a/src/test/java/com/gisgro/TestEntity5.java
+++ b/src/test/java/com/gisgro/TestEntity5.java
@@ -1,0 +1,30 @@
+package com.gisgro;
+
+import com.gisgro.annotations.Searchable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TestEntity5 {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Searchable
+  @OneToMany(mappedBy = "entity5")
+  private List<TestEntity> nestedList = new ArrayList<>();
+
+}

--- a/src/test/java/com/gisgro/TestEntity5Repository.java
+++ b/src/test/java/com/gisgro/TestEntity5Repository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TestEntity2Repository extends JpaRepository<TestEntity2, Long>, JpaSpecificationExecutor<TestEntity2> {
+public interface TestEntity5Repository extends JpaRepository<TestEntity5, Long>, JpaSpecificationExecutor<TestEntity5> {
+
 }


### PR DESCRIPTION
### RFC on test cases:

has simple nested filter
`
["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]]
`

`
   ["has", "nestedSet", ["contains", ["field", "string"], "nested"]]
`

`
 ["has", "nestedSet", ["isNull", ["field", "string"]]]
`

`
  ["isNull", ["field", "string"]]
`
with "and" mixed in
`
        ["has", "nestedSet", ["and", ["eq", ["field", "string"], "nestedSet0"], ["eq", ["field", "string"], "nestedSet1"]]]
`

`
["and", ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]], ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet1"]]]
`

with "not" mixed in
`
["not", ["has", "nestedSet", ["and", ["isNull", ["field", "string"]]]]]
`
`
  ["has", "nestedSet", ["not", ["isNull", ["field", "string"]]]]
`


double nested cases
`
   ["has", "nestedList", ["has", "nestedSet", ["eq", ["field", "string"], "nestedSet0"]]]
`
`
  ["has", "nestedList", ["has", "nestedSet", ["not", ["contains", ["field", "string"], "nestedSet"]]]]
`

collection is in nestedSearchable
`
   ["has", "entity1.nestedSet", ["contains", ["field", "string"], "nestedSet"]]
`


### Use 
To use these the collection attribute needs to be annotated with `@CollectionSearchable` which provides the necessary typing and if needed back reference (Can also be provided via JPA annotation `@OneToMany`).

### Cyclic references
Using this and the `@NestedSearchable` use case results quite fast in cyclic references. To combat this, the nesting terminates when a cyclic reference is noticed. This does not brake working solutions. Only if for some unfathomable reason someone relies on a stack overflow in here, they are affected.















